### PR TITLE
feat: Add comprehensive logging for non-2xx HTTP response codes

### DIFF
--- a/http/http_sink.go
+++ b/http/http_sink.go
@@ -275,11 +275,11 @@ func (h *HTTPSink) retryExecute(method, url string, headers map[string]string,
 				log.Printf("backoff.Stop returned, using max interval %s", expBackoff.MaxInterval)
 				nextDelay = expBackoff.MaxInterval
 			}
-			log.Printf("retryExecute with backoff nextDelay %s \t %s \t %s \n", method, url, nextDelay)
+			log.Printf("retryExecuteee with backoff nextDelay %s \t %s \t %s \n", method, url, nextDelay)
 		} else {
 			// Use the configured fixed retry interval
 			nextDelay = h.conf.RetryInterval.Duration
-			log.Printf("retryExecute nextDelay %s \t %s \t %s \n", method, url, nextDelay)
+			log.Printf("retryExecuteee nextDelay %s \t %s \t %s \n", method, url, nextDelay)
 		}
 		time.Sleep(nextDelay)
 	}

--- a/http/http_sink.go
+++ b/http/http_sink.go
@@ -246,12 +246,23 @@ func (h *HTTPSink) retryExecute(method, url string, headers map[string]string,
 			nonRetriableHttpStatusCodes := h.conf.NonRetriableHttpStatusCodes
 			err, outcome := respEval(respCode, nonRetriableHttpStatusCodes)
 			if err == nil {
+				// Log successful responses (2xx) for debugging
+				if respCode >= 200 && respCode < 300 {
+					log.Printf("HTTP request succeeded with status code %d for %s %s", respCode, method, url)
+				}
 				return outcome, nil
+			}
+			// Log non-2xx response codes with more context
+			if respCode >= 300 {
+				log.Printf("HTTP request failed with status code %d for %s %s (retry attempt %d)", respCode, method, url, count+1)
 			}
 			count = count + 1
 			if core.Contains(sidelineResponseCodes, respCode) || (retries != 0 && retries != math.MaxInt32 && count > retries) {
 				return outcome, errors.New(core.SidelineMessage)
 			}
+		} else {
+			// Log HTTP request execution failures
+			log.Printf("HTTP request execution failed for %s %s", method, url)
 		}
 
 		// Determine the next delay

--- a/sample.yaml
+++ b/sample.yaml
@@ -1,0 +1,65 @@
+go-dmux:
+  resources:
+    cpu: 2
+    memory: 10Gi
+
+  replicaCount: 1
+
+  annotations: |-
+    fcp.k8s.mtl/mtl-config: {{ .Values.global.name }}-mtl-config
+
+  dmux:
+    connections:
+      a2o-update-external-event-consumer:
+        type: kafka_http
+        sinkSize: 10
+        sourceQueueSize: 10
+        sinkQueueSize: 10
+        distributorType: Hash
+        batchSize: 1
+        pendingAcks: "10"
+        source:
+          consumerGroupName: a2o-update-external-event-consumer
+          zkPath: 10.66.158.162,10.67.222.87,10.68.221.245,10.68.158.50,10.69.30.89:2181/em-client-kafka-1
+          kafkaVersion: 2
+          kafkaTopic: entity-a2o-update-cdc-yak-0
+          forceRestart: false
+          readNewest: false
+          saslEnabled: true
+          username: emuser
+          passwordKey: KAFKA_CLIENT_USER_PASSWORD
+        sink:
+          endpoint: http://10.83.69.160/entity-manager/v1/entity/manager/dmux/em-event-consumer
+          method: POST
+          timeout: 10s
+          retryInterval: 1000ms
+          headers:
+            EVENT-COMPONENTS: A2O_EXTERNAL_EVENT_CONSUMER
+            SYNC-ENTITY: false
+            SYNC-INDEX: true
+            SYNC-AUDIT: false
+            CHECK-OB-FLAG: false
+
+      a2o-cdc-consumer:
+        type: kafka_http
+        sinkSize: 64
+        sourceQueueSize: 64
+        sinkQueueSize: 64
+        distributorType: Hash
+        batchSize: 1
+        pendingAcks: "10"
+        source:
+          consumerGroupName: a2o-cdc-consumer
+          zkPath: 10.66.158.162,10.67.222.87,10.68.221.245,10.68.158.50,10.69.30.89:2181/em-client-kafka-1
+          kafkaVersion: 2
+          kafkaTopic: a2o-cdc
+          forceRestart: false
+          readNewest: false
+          saslEnabled: true
+          username: emuser
+          passwordKey: KAFKA_CLIENT_USER_PASSWORD
+        sink:
+          endpoint: http://10.24.41.229/access/store/cdcEvents
+          method: POST
+          timeout: 10s
+          retryInterval: 100ms


### PR DESCRIPTION
- Enhanced HTTP sink to log non-2xx response codes with retry attempt context
- Added logging for HTTP request execution failures
- Improved batch processing error handling to prevent application termination
- Enhanced hook implementations (Kafka and Pulsar) with detailed success/failure logging
- Added logging for successful responses (2xx) for debugging purposes
- Updated test hooks to provide better debugging information

This change provides better visibility into HTTP request failures and helps with debugging and monitoring the go-dmux application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sample configuration demonstrating two Kafka-to-HTTP consumer connections with resource and connection parameters.

* **Enhancements**
  * Improved HTTP request logging for retries: clearer success and failure messages, explicit logs for execution failures, and more informative retry delay messages to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->